### PR TITLE
feat: build arm64 / aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         distro: [focal, bionic]
-        arch: [x86_64]
+        arch: [x86_64, aarch64]
 
     env:
       DISTRO: ${{ matrix.distro }} # build target, name required by binary-builder


### PR DESCRIPTION
Build `arm64` binaries to later build the `arm64` docker images.

- https://github.com/containerbase/base/issues/711
- renovatebot/renovate#9229